### PR TITLE
feat: Update version to 1.2.3-stable across all relevant files

### DIFF
--- a/Scripts/installer.sh
+++ b/Scripts/installer.sh
@@ -7,7 +7,7 @@ ARCH=$(dpkg --print-architecture)
 
 echo "Detected architecture: $ARCH"
 
-VERSION="1.1.2-stable"
+VERSION="1.2.3-stable"
 
 if [[ "$ARCH" == "amd64" ]]; then
   PKG="xpack_${VERSION}_amd64.deb"

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.1.2-stable
+1.2.3-stable

--- a/src/Core/main.go
+++ b/src/Core/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 // var VERSION is updated by Scripts/versionController.sh
-var VERSION = "1.1.2-stable"
+var VERSION = "1.2.3-stable"
 
 // readLineRaw reads interactive input from terminal in raw mode, supporting Tab completion
 func readLineRaw(promptText, defaultVal string) (string, error) {
@@ -311,7 +311,14 @@ func main() {
 	}
 
 	// infer app name from binary filename
-	appName := filepath.Base(inputPath)
+	var appName string
+	defaultCandidate := filepath.Base(inputPath)
+	 v, _ := readLineRaw("Application name for this package", filepath.Base(inputPath))
+		if v != "" {
+					appName = v
+				} else {
+					appName = defaultCandidate
+				}
 	// remove extension
 	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
 

--- a/src/base/banner.go
+++ b/src/base/banner.go
@@ -5,7 +5,7 @@ import (
 )
 
 // const Version is kept so external scripts can update it via sed
-const Version = "1.1.2-stable"
+const Version = "1.2.3-stable"
 
 // PrintBanner prints a simple welcome banner. Version may be empty.
 func PrintBanner(version string) {


### PR DESCRIPTION
This pull request updates the project to version `1.2.3-stable` and introduces a prompt for customizing the application name during packaging. The most important changes are grouped below:

Version update across the codebase:

* Updated the version from `1.1.2-stable` to `1.2.3-stable` in the `VERSION` file, `Scripts/installer.sh`, `src/Core/main.go`, and `src/base/banner.go` to reflect the new release version. [[1]](diffhunk://#diff-7b60b8e351cbb80c47459ffe2c79f1a26404871f49294780fe47ad0e58c09350L1-R1) [[2]](diffhunk://#diff-bbd56f56ab68b4cefa4894fc43729843af07fe9b1fcaf0a2ae24fcea5965462fL10-R10) [[3]](diffhunk://#diff-7b41ad11053120327003ac33eecb4df02db27d79cc299e913f7425f2f02bf6fcL18-R18) [[4]](diffhunk://#diff-504d2ba391289ec5bf3702c38cb7e758258581a44f28fdf0af1b99bff42594b4L8-R8)

Packaging flow improvement:

* Modified the packaging logic in `src/Core/main.go` to prompt the user for an application name when creating a package, defaulting to the binary filename if no input is provided. This makes the packaging process more flexible and user-friendly.