### PR TITLE
feat: Update version to 1.2.4-stable across relevant files and workflows

### DIFF
--- a/.github/workflows/run_build.yml
+++ b/.github/workflows/run_build.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   run-script:
     runs-on: ubuntu-latest
+    environment: production # Set the environment to production to access its secrets
 
     steps:
       - name: 📥 Checkout code

--- a/Scripts/installer.sh
+++ b/Scripts/installer.sh
@@ -7,7 +7,7 @@ ARCH=$(dpkg --print-architecture)
 
 echo "Detected architecture: $ARCH"
 
-VERSION="1.2.3-stable"
+VERSION="1.2.4-stable"
 
 if [[ "$ARCH" == "amd64" ]]; then
   PKG="xpack_${VERSION}_amd64.deb"

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.2.3-stable
+1.2.4-stable

--- a/src/Core/main.go
+++ b/src/Core/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 // var VERSION is updated by Scripts/versionController.sh
-var VERSION = "1.2.3-stable"
+var VERSION = "1.2.4-stable"
 
 // readLineRaw reads interactive input from terminal in raw mode, supporting Tab completion
 func readLineRaw(promptText, defaultVal string) (string, error) {

--- a/src/base/banner.go
+++ b/src/base/banner.go
@@ -5,7 +5,7 @@ import (
 )
 
 // const Version is kept so external scripts can update it via sed
-const Version = "1.2.3-stable"
+const Version = "1.2.4-stable"
 
 // PrintBanner prints a simple welcome banner. Version may be empty.
 func PrintBanner(version string) {


### PR DESCRIPTION
This pull request updates the project version from `1.2.3-stable` to `1.2.4-stable` across all relevant files and configures the build workflow to use the production environment for accessing secrets.

Version bump to `1.2.4-stable`:

* Updated the version string in the `VERSION` file.
* Changed the `VERSION` variable in `Scripts/installer.sh` to `1.2.4-stable`.
* Updated the `VERSION` variable in `src/Core/main.go` to `1.2.4-stable`.
* Changed the `Version` constant in `src/base/banner.go` to `1.2.4-stable`.

Build workflow configuration:

* Set the environment to production in `.github/workflows/run_build.yml` to allow access to production secrets.