### PR TITLE
feat: Update version to 1.2.5-stable across relevant files

### DIFF
--- a/Scripts/installer.sh
+++ b/Scripts/installer.sh
@@ -7,7 +7,7 @@ ARCH=$(dpkg --print-architecture)
 
 echo "Detected architecture: $ARCH"
 
-VERSION="1.2.4-stable"
+VERSION="1.2.5-stable"
 
 if [[ "$ARCH" == "amd64" ]]; then
   PKG="xpack_${VERSION}_amd64.deb"

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.2.4-stable
+1.2.5-stable

--- a/src/Core/main.go
+++ b/src/Core/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 // var VERSION is updated by Scripts/versionController.sh
-var VERSION = "1.2.4-stable"
+var VERSION = "1.2.5-stable"
 
 // readLineRaw reads interactive input from terminal in raw mode, supporting Tab completion
 func readLineRaw(promptText, defaultVal string) (string, error) {

--- a/src/base/banner.go
+++ b/src/base/banner.go
@@ -5,7 +5,7 @@ import (
 )
 
 // const Version is kept so external scripts can update it via sed
-const Version = "1.2.4-stable"
+const Version = "1.2.5-stable"
 
 // PrintBanner prints a simple welcome banner. Version may be empty.
 func PrintBanner(version string) {


### PR DESCRIPTION
This pull request updates the version of the application from `1.2.4-stable` to `1.2.5-stable` across all relevant files to prepare for a new release. No other changes are included.

Version bump:

* Updated the version string in `Scripts/installer.sh` to `1.2.5-stable` for package naming and installation.
* Updated the `VERSION` file to reflect the new version.
* Updated the `VERSION` variable in `src/Core/main.go` to `1.2.5-stable`.
* Updated the `Version` constant in `src/base/banner.go` to `1.2.5-stable`.