### PR TITLE
feat: Update version to 2.2.5-stable across relevant files

### DIFF
--- a/Scripts/installer.sh
+++ b/Scripts/installer.sh
@@ -7,7 +7,7 @@ ARCH=$(dpkg --print-architecture)
 
 echo "Detected architecture: $ARCH"
 
-VERSION="1.2.5-stable"
+VERSION="2.2.5-stable"
 
 if [[ "$ARCH" == "amd64" ]]; then
   PKG="xpack_${VERSION}_amd64.deb"

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-1.2.5-stable
+2.2.5-stable

--- a/src/Core/main.go
+++ b/src/Core/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 // var VERSION is updated by Scripts/versionController.sh
-var VERSION = "1.2.5-stable"
+var VERSION = "2.2.5-stable"
 
 // readLineRaw reads interactive input from terminal in raw mode, supporting Tab completion
 func readLineRaw(promptText, defaultVal string) (string, error) {
@@ -252,6 +252,7 @@ func main() {
 	inputFlag := flag.String("i", "", "relative path to input binary")
 	archFlag := flag.String("arch", "", "target architecture (amd64, arm64, i386)")
 	verFlag := flag.String("v", "", "version string for the package (e.g. 1.1.1)")
+	appFlag := flag.String("app", "", "application name for the package")
 	flag.Parse()
 
 	// show banner
@@ -310,17 +311,23 @@ func main() {
 		os.Exit(1)
 	}
 
-	// infer app name from binary filename
+	// determine app name: use flag if provided, otherwise prompt interactively
 	var appName string
-	defaultCandidate := filepath.Base(inputPath)
-	 v, _ := readLineRaw("Application name for this package", filepath.Base(inputPath))
+	if *appFlag != "" {
+		appName = *appFlag
+	} else {
+		// infer default from binary filename
+		defaultCandidate := filepath.Base(inputPath)
+		// remove extension from default
+		defaultCandidate = strings.TrimSuffix(defaultCandidate, filepath.Ext(defaultCandidate))
+
+		v, _ := readLineRaw("Application name for this package", defaultCandidate)
 		if v != "" {
-					appName = v
-				} else {
-					appName = defaultCandidate
-				}
-	// remove extension
-	appName = strings.TrimSuffix(appName, filepath.Ext(appName))
+			appName = v
+		} else {
+			appName = defaultCandidate
+		}
+	}
 
 	// determine package version:
 	// - if -v provided, use it

--- a/src/base/banner.go
+++ b/src/base/banner.go
@@ -5,7 +5,7 @@ import (
 )
 
 // const Version is kept so external scripts can update it via sed
-const Version = "1.2.5-stable"
+const Version = "2.2.5-stable"
 
 // PrintBanner prints a simple welcome banner. Version may be empty.
 func PrintBanner(version string) {


### PR DESCRIPTION
This pull request updates the application version from `1.2.5-stable` to `2.2.5-stable` across all relevant files and improves how the application name is determined during packaging. The main change is to allow users to specify the application name via a new command-line flag, falling back to an interactive prompt only if the flag is not provided.

Version update:

* Updated the version string from `1.2.5-stable` to `2.2.5-stable` in `VERSION`, `Scripts/installer.sh`, `src/Core/main.go`, and `src/base/banner.go`. [[1]](diffhunk://#diff-7b60b8e351cbb80c47459ffe2c79f1a26404871f49294780fe47ad0e58c09350L1-R1) [[2]](diffhunk://#diff-bbd56f56ab68b4cefa4894fc43729843af07fe9b1fcaf0a2ae24fcea5965462fL10-R10) [[3]](diffhunk://#diff-7b41ad11053120327003ac33eecb4df02db27d79cc299e913f7425f2f02bf6fcL18-R18) [[4]](diffhunk://#diff-504d2ba391289ec5bf3702c38cb7e758258581a44f28fdf0af1b99bff42594b4L8-R8)

Packaging workflow improvements:

* Added a new `-app` command-line flag to `src/Core/main.go` to allow specifying the application name directly when packaging.
* Changed logic in `src/Core/main.go` so the application name is taken from the flag if provided, otherwise prompts the user interactively, defaulting to the binary filename without extension.