### PR TITLE
refactor: Update PackageBuilder and release scripts for improved pack…

### DIFF
--- a/Scripts/PackageBuilder.sh
+++ b/Scripts/PackageBuilder.sh
@@ -1,82 +1,48 @@
 #!/bin/bash
 
-# Options
-FILE_TYPE=("deb" "tar.gz")
-AVAILABLE_OPTIONS=("amd64" "arm64" "i386")
-FOLDER_NAME="Packages"
+# === CONFIG ===
+APP_NAME="xpack"
+BINARY_PATH="./bin/xpack"
+VERSION_FILE="./VERSION"
+AVAILABLE_ARCHITECTURES=("amd64" "arm64" "i386")
 
-for TYPE in "${FILE_TYPE[@]}"; do
-  for ARCH in "${AVAILABLE_OPTIONS[@]}"; do
-    echo "Building $TYPE package for architecture: $ARCH"
+# === Get version from VERSION file ===
+if [ -f "$VERSION_FILE" ]; then
+  VERSION=$(cat "$VERSION_FILE" | tr -d '[:space:]')
+else
+  echo "❌ VERSION file not found in project Core"
+  exit 1
+fi
 
-    # === CONFIG ===
-    APP_NAME="xpack"
-    # ARCH is set by outer loop
-    MAINTAINER="Ankan Saha <ankansahaofficial@gmail.com>"
-    DESCRIPTION="A short summary of what your program does."
-    BINARY_PATH="./bin/xpack" # Path to your Go binary
-    VERSION_FILE="./VERSION"
+# === Check binary ===
+if [ ! -f "$BINARY_PATH" ]; then
+  echo "❌ Binary not found at $BINARY_PATH"
+  exit 1
+fi
 
-    # === Get version from VERSION file ===
-    if [ -f "$VERSION_FILE" ]; then
-      VERSION=$(cat "$VERSION_FILE" | tr -d '[:space:]')
-    else
-      echo "❌ VERSION file not found in project Core"
-      exit 1
-    fi
+# === Install xpack ===
+echo "📦 Installing xpack..."
+curl -fsSL https://raw.githubusercontent.com/nexoral/xpack/main/Scripts/installer.sh | sudo bash -
 
-    # === Check binary ===
-    if [ ! -f "$BINARY_PATH" ]; then
-      echo "❌ Binary not found at $BINARY_PATH"
-      exit 1
-    fi
+if [ $? -ne 0 ]; then
+  echo "❌ Failed to install xpack"
+  exit 1
+fi
 
-    # Build per package type
-    case "$TYPE" in
-    deb)
-      # === Create folder structure for .deb ===
-      PKG_DIR="${APP_NAME}_${VERSION}_${ARCH}"
-      mkdir -p "$PKG_DIR/DEBIAN"
-      mkdir -p "$PKG_DIR/usr/local/bin"
+echo "✅ xpack installed successfully"
 
-      # === Write control file ===
-      cat <<EOF >"$PKG_DIR/DEBIAN/control"
-Package: $APP_NAME
-Version: $VERSION
-Section: utils
-Priority: optional
-Architecture: $ARCH
-Maintainer: $MAINTAINER
-Description: $DESCRIPTION
-EOF
+# === Build packages for each architecture ===
+for ARCH in "${AVAILABLE_ARCHITECTURES[@]}"; do
+  echo "🔨 Building packages for architecture: $ARCH"
 
-      # === Copy binary ===
-      cp "$BINARY_PATH" "$PKG_DIR/usr/local/bin/$APP_NAME"
-      chmod 755 "$PKG_DIR/usr/local/bin/$APP_NAME"
+  xpack -i "$BINARY_PATH" -app "$APP_NAME" -arch "$ARCH" -v "$VERSION"
 
-      # === Build the .deb ===
-      dpkg-deb --build "$PKG_DIR"
+  if [ $? -ne 0 ]; then
+    echo "❌ Failed to build packages for architecture: $ARCH"
+    exit 1
+  fi
 
-      # === Move and clean up ===
-      if [ ! -d "$FOLDER_NAME" ]; then
-        echo "Creating $FOLDER_NAME directory..."
-        mkdir $FOLDER_NAME
-      else
-        echo "$FOLDER_NAME directory already exists."
-      fi
-      mv "${PKG_DIR}.deb" "./$FOLDER_NAME/${APP_NAME}_${VERSION}_${ARCH}.deb"
-      rm -rf "$PKG_DIR"
-      ;;
-    tar.gz)
-      # === Build tar.gz ===
-      TMPDIR="$(mktemp -d)"
-      mkdir -p "$TMPDIR/usr/local/bin"
-      cp "$BINARY_PATH" "$TMPDIR/usr/local/bin/$APP_NAME"
-      tar czf "./$FOLDER_NAME/${APP_NAME}_${VERSION}_${ARCH}.tar.gz" -C "$TMPDIR" .
-      rm -rf "$TMPDIR"
-      ;;
-    esac
-
-    echo "✅ $TYPE package created: ${APP_NAME}_${VERSION}_${ARCH}.${TYPE}"
-  done
+  echo "✅ Packages created for architecture: $ARCH"
 done
+
+echo "🎉 All packages built successfully and saved to dist folder"

--- a/Scripts/installer.sh
+++ b/Scripts/installer.sh
@@ -7,7 +7,7 @@ ARCH=$(dpkg --print-architecture)
 
 echo "Detected architecture: $ARCH"
 
-VERSION="2.2.5-stable"
+VERSION="2.2.6-stable"
 
 if [[ "$ARCH" == "amd64" ]]; then
   PKG="xpack_${VERSION}_amd64.deb"

--- a/Scripts/release.sh
+++ b/Scripts/release.sh
@@ -15,8 +15,8 @@ echo "🔨 Binary Building completed of $APP_NAME version $VERSION for $ARCH"
 ./Scripts/PackageBuilder.sh
 echo "📦 Package Building completed of $APP_NAME version $VERSION for $ARCH"
 
-# collect all debs for this version
-DEB_FILES=(./Packages/${APP_NAME}_${VERSION}_*) # to collect all files
+# collect all packages for this version from dist folder
+DEB_FILES=(./dist/${APP_NAME}_${VERSION}_*) # to collect all files (.deb and .tar.gz)
 
 TAG="v$VERSION"
 COMMIT_HASH=$(git rev-parse HEAD)
@@ -32,9 +32,9 @@ if [ ! -f "$VERSION_FILE" ]; then
   exit 1
 fi
 
-# ensure we have at least one .deb
+# ensure we have at least one package file
 if [ ${#DEB_FILES[@]} -eq 0 ]; then
-  echo "❌ No .deb files found for version $VERSION in Packages/"
+  echo "❌ No package files found for version $VERSION in dist/"
   exit 1
 fi
 
@@ -74,7 +74,7 @@ gh release create "$TAG" "${DEB_FILES[@]}" \
 📝 Message:
 $COMMIT_MSG"
 
-echo "✅ GitHub release published with .deb assets"
+echo "✅ GitHub release published with package assets (.deb and .tar.gz)"
 
 # --- Cleanup old releases, keep only latest two ---
 echo "🗑️ Cleaning up old releases, retaining only latest two"

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.2.5-stable
+2.2.6-stable

--- a/src/Core/main.go
+++ b/src/Core/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 // var VERSION is updated by Scripts/versionController.sh
-var VERSION = "2.2.5-stable"
+var VERSION = "2.2.6-stable"
 
 // readLineRaw reads interactive input from terminal in raw mode, supporting Tab completion
 func readLineRaw(promptText, defaultVal string) (string, error) {

--- a/src/base/banner.go
+++ b/src/base/banner.go
@@ -5,7 +5,7 @@ import (
 )
 
 // const Version is kept so external scripts can update it via sed
-const Version = "2.2.5-stable"
+const Version = "2.2.6-stable"
 
 // PrintBanner prints a simple welcome banner. Version may be empty.
 func PrintBanner(version string) {


### PR DESCRIPTION
This pull request refactors the package building and release process to use the `xpack` installer and tool for packaging, simplifies the build script, and standardizes the output location for built packages. The changes streamline package creation for multiple architectures and ensure all package types are handled consistently in the release workflow.

**Build Script Refactor and Packaging Process:**

* The `Scripts/PackageBuilder.sh` script is rewritten to install `xpack` via a remote installer and use it to build packages for each architecture, replacing the previous manual logic for building `.deb` and `.tar.gz` packages. Output is now consistently placed in a `dist` folder. [[1]](diffhunk://#diff-7b6add39d2ab8a9fd3db18c1987e5a27ccd2cabcb4643d799b24c70cda9eba4aL3-R7) [[2]](diffhunk://#diff-7b6add39d2ab8a9fd3db18c1987e5a27ccd2cabcb4643d799b24c70cda9eba4aL34-R48)

**Release Script Updates:**

* The `Scripts/release.sh` script is updated to collect all built packages (both `.deb` and `.tar.gz`) from the `dist` folder, ensuring all package types are included in the release.
* The script now checks for the presence of any package files (not just `.deb`) in `dist` before proceeding with the release.
* The release confirmation message is updated to reflect that both `.deb` and `.tar.gz` assets are published.…age handling