### PR TITLE
chore: Update version to 2.2.7-stable and adjust related scripts

### DIFF
--- a/Scripts/PackageBuilder.sh
+++ b/Scripts/PackageBuilder.sh
@@ -20,22 +20,11 @@ if [ ! -f "$BINARY_PATH" ]; then
   exit 1
 fi
 
-# === Install xpack ===
-echo "📦 Installing xpack..."
-curl -fsSL https://raw.githubusercontent.com/nexoral/xpack/main/Scripts/installer.sh | sudo bash -
-
-if [ $? -ne 0 ]; then
-  echo "❌ Failed to install xpack"
-  exit 1
-fi
-
-echo "✅ xpack installed successfully"
-
 # === Build packages for each architecture ===
 for ARCH in "${AVAILABLE_ARCHITECTURES[@]}"; do
   echo "🔨 Building packages for architecture: $ARCH"
 
-  xpack -i "$BINARY_PATH" -app "$APP_NAME" -arch "$ARCH" -v "$VERSION"
+  "$BINARY_PATH" -i "$BINARY_PATH" -app "$APP_NAME" -arch "$ARCH" -v "$VERSION"
 
   if [ $? -ne 0 ]; then
     echo "❌ Failed to build packages for architecture: $ARCH"

--- a/Scripts/installer.sh
+++ b/Scripts/installer.sh
@@ -7,7 +7,7 @@ ARCH=$(dpkg --print-architecture)
 
 echo "Detected architecture: $ARCH"
 
-VERSION="2.2.6-stable"
+VERSION="2.2.7-stable"
 
 if [[ "$ARCH" == "amd64" ]]; then
   PKG="xpack_${VERSION}_amd64.deb"

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-2.2.6-stable
+2.2.7-stable

--- a/src/Core/main.go
+++ b/src/Core/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 // var VERSION is updated by Scripts/versionController.sh
-var VERSION = "2.2.6-stable"
+var VERSION = "2.2.7-stable"
 
 // readLineRaw reads interactive input from terminal in raw mode, supporting Tab completion
 func readLineRaw(promptText, defaultVal string) (string, error) {

--- a/src/base/banner.go
+++ b/src/base/banner.go
@@ -5,7 +5,7 @@ import (
 )
 
 // const Version is kept so external scripts can update it via sed
-const Version = "2.2.6-stable"
+const Version = "2.2.7-stable"
 
 // PrintBanner prints a simple welcome banner. Version may be empty.
 func PrintBanner(version string) {


### PR DESCRIPTION
This pull request updates the project version from `2.2.6-stable` to `2.2.7-stable` across the codebase and scripts, and removes the installation of `xpack` from the package building script. The most important changes are:

**Version Bump:**

* Updated the version number from `2.2.6-stable` to `2.2.7-stable` in `VERSION`, `src/Core/main.go`, `src/base/banner.go`, and `Scripts/installer.sh` to ensure consistency across the project. [[1]](diffhunk://#diff-7b60b8e351cbb80c47459ffe2c79f1a26404871f49294780fe47ad0e58c09350L1-R1) [[2]](diffhunk://#diff-7b41ad11053120327003ac33eecb4df02db27d79cc299e913f7425f2f02bf6fcL18-R18) [[3]](diffhunk://#diff-504d2ba391289ec5bf3702c38cb7e758258581a44f28fdf0af1b99bff42594b4L8-R8) [[4]](diffhunk://#diff-bbd56f56ab68b4cefa4894fc43729843af07fe9b1fcaf0a2ae24fcea5965462fL10-R10)

**Build Script Simplification:**

* Removed the installation step for `xpack` from `Scripts/PackageBuilder.sh` and updated the build command to invoke the binary directly, streamlining the package build process.